### PR TITLE
Fixing bash treating some days of the year as octals

### DIFF
--- a/ddate.sh
+++ b/ddate.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
-gd=`date +%j`
+gd=10#`date +%j`
 gy=`date +%Y`
-
-# fix bash treating some numbers as octals
-let "gd=10#${gd}"
 
 m=$((gd / 73))
 d=$(((gd - 1) % 73))

--- a/ddate.sh
+++ b/ddate.sh
@@ -5,7 +5,6 @@ gy=`date +%Y`
 
 # fix bash treating some numbers as octals
 let "gd=10#${gd}"
-let "gy=10#${gy}"
 
 m=$((gd / 73))
 d=$(((gd - 1) % 73))

--- a/ddate.sh
+++ b/ddate.sh
@@ -3,6 +3,10 @@
 gd=`date +%j`
 gy=`date +%Y`
 
+# fix bash treating some numbers as octals
+let "gd=10#${gd}"
+let "gy=10#${gy}"
+
 m=$((gd / 73))
 d=$(((gd - 1) % 73))
 u=$((d % 5))


### PR DESCRIPTION
`date +%j` always outputs days of the year with 3 digits. If it's the 8th 9th day of the year, it will show them as 008 or 009, which Bash treats as octal numbers. This, on January 8th and 9th results in this error:

```
./ddate.sh: line 6: 009: value too great for base (error token is "009")
./ddate.sh: line 7: 009: value too great for base (error token is "009")
```

My commit fixes it by removing leading zeroes.